### PR TITLE
fix spelling of 'version'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2241,7 +2241,7 @@ Role Variables
 - `umc_policies_maintenance_patchhour`(string): The chosen hour for univention-update; default: `5`.
 - `umc_policies_maintenance_patchminute`(string): The choosen minute for univention-update; default: `00`.
 - `umc_policies_maintenance_patchday`(String): The chosen day for univention-update; default: `Tuesday`.
-- `umc_policies_maintenance_release_verion`(string): The univention release version.
+- `umc_policies_maintenance_release_version`(string): The univention release version.
 - `umc_policies_maintenance_hostname`(string): The systems hostname; default: `"{{ inventory_hostname }}"`
 
 Dependencies

--- a/roles/umc_policies_maintenance/README.md
+++ b/roles/umc_policies_maintenance/README.md
@@ -16,7 +16,7 @@ Role Variables
 - `umc_policies_maintenance_patchhour`(string): The chosen hour for univention-update; default: `5`.
 - `umc_policies_maintenance_patchminute`(string): The choosen minute for univention-update; default: `00`.
 - `umc_policies_maintenance_patchday`(String): The chosen day for univention-update; default: `Tuesday`.
-- `umc_policies_maintenance_release_verion`(string): The univention release version.
+- `umc_policies_maintenance_release_version`(string): The univention release version.
 - `umc_policies_maintenance_hostname`(string): The systems hostname; default: `"{{ inventory_hostname }}"`
 
 Dependencies

--- a/roles/umc_policies_maintenance/defaults/main.yml
+++ b/roles/umc_policies_maintenance/defaults/main.yml
@@ -4,6 +4,6 @@ umc_policies_maintenance_basedn: ""
 umc_policies_maintenance_patchhour: "5"
 umc_policies_maintenance_patchminute: "00"
 umc_policies_maintenance_patchday: "Tuesday"
-umc_policies_maintenance_release_verion: ""
+umc_policies_maintenance_release_version: ""
 umc_policies_maintenance_hostname: "{{ inventory_hostname }}"
 umc_policies_maintenance_autoupdate_enabled: true

--- a/roles/umc_policies_maintenance/tasks/main.yml
+++ b/roles/umc_policies_maintenance/tasks/main.yml
@@ -57,7 +57,7 @@
           - "--dn"
           - "cn=app-release-update,cn=policies,{{ umc_policies_maintenance_basedn }}"
           - "--set"
-          - "releaseVersion={{ umc_policies_maintenance_release_verion }}"
+          - "releaseVersion={{ umc_policies_maintenance_release_version }}"
       changed_when: "umc_policies_maintenance_edit_release_result.stdout is not search('No modification')"
       register: "umc_policies_maintenance_edit_release_result"
       tags:


### PR DESCRIPTION
The drawback is that it isn't backwards-compatible with the misspelled variable. Could easily be worked around by using something like this in `tasks/main.yml`:

```
          - "releaseVersion={{ umc_policies_maintenance_release_verion if umc_policies_maintenance_release_verion is defined else umc_policies_maintenance_release_version }}"
```